### PR TITLE
Use specific ruby buildpack for does_not_stage_on_fs4 app

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Integration", Label("integration"), func() {
 		When("the app cannot stage on the target stack", func() {
 			It("restarts itself on the old stack", func() {
 				app := cutlass.New(filepath.Join("testdata", "does_not_stage_on_fs4"))
-				app.Buildpacks = []string{"https://github.com/cloudfoundry/ruby-buildpack#master"}
+				app.Buildpacks = []string{"https://github.com/cloudfoundry/ruby-buildpack#v1.9.4"}
 				app.Stack = oldStack
 				app.Disk = disk
 				app.Memory = memory


### PR DESCRIPTION
- the last buildpack with ruby 2.7 support is v1.9.4 so hardcode to that instead of using master branch
- the test works by having the app use 2.7 on cflinuxfs3, but 2.7 is not supported on cflinuxfs4