### PR TITLE
Restore app state when change stack fails

### DIFF
--- a/changer/changer.go
+++ b/changer/changer.go
@@ -14,6 +14,7 @@ const (
 	RestoringStateMsg          = "Restoring prior application state: %s"
 	ErrorChangingStack         = "problem assigning target stack to %s"
 	ErrorRestagingApp          = "problem restaging app on %s"
+	ErrorRestoringState        = "problem restoring application state to %s"
 )
 
 type RequestData struct {
@@ -66,6 +67,9 @@ func (c *Changer) change(appName, appGUID, oldStack, newStack, appInitialState s
 		err = fmt.Errorf(ErrorRestagingApp+": %w", newStack, err)
 		if restartErr := c.assignTargetStack(appGUID, oldStack); restartErr != nil {
 			err = fmt.Errorf(ErrorChangingStack+": %w", oldStack, err)
+		}
+		if restoreErr := c.restoreAppState(appGUID, appInitialState); restoreErr != nil {
+			err = fmt.Errorf(ErrorRestoringState+": %w", appInitialState, err)
 		}
 		return err
 	}


### PR DESCRIPTION
related to:
https://github.com/cloudfoundry/stack-auditor/issues/33

When change-stack fails and the application is `stopped` stack-auditor is leaving the app in the `started` state.
This changes the behavior of the changer, so it always restores the application state to the initial state.

[#185222886] If changing the stack fails app state is not restored