### PR TITLE
Escape app name

### DIFF
--- a/cf/cf.go
+++ b/cf/cf.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	plugin_models "code.cloudfoundry.org/cli/plugin/models"
@@ -159,7 +160,7 @@ func (cf *CF) GetAppByName(appName string) (resources.V3App, error) {
 	var apps resources.V3AppsJSON
 	var app resources.V3App
 
-	endpoint := fmt.Sprintf("/v3/apps?names=%s&space_guids=%s", appName, cf.Space.Guid)
+	endpoint := fmt.Sprintf("/v3/apps?names=%s&space_guids=%s", url.QueryEscape(appName), cf.Space.Guid)
 	appJSON, err := cf.CFCurl(endpoint)
 	if err != nil {
 		return app, err


### PR DESCRIPTION
Current behaviour:
```
cf change-stack static#blue cflinuxfs3
Attempting to change stack to cflinuxfs3 for perf-space-5403ca46-a079-11ef-bb1e-02420a0a0007/static#blue/...

2024/11/12 10:04:46 a problem occurred: no app found with name static#blue
```

```
$ cf curl "/v3/apps?names=static#blue"
{"pagination":{"total_results":0,"total_pages":1,"first":
{"href":"https://api.sys.tas.z3c9041a1.shepherd.lease/v3/apps?names=staticblue\u0026page=1\u0026per_page=50"}
,"last":{"href":"https://api.sys.tas.z3c9041a1.shepherd.lease/v3/apps?names=staticblue\u0026page=1\u0026per_page=50"},"next":null,"previous":null},"resources":[]}
 ```
 
With proper escaping:
```
cf change-stack static#blue cflinuxfs4
Attempting to change stack to cflinuxfs4 for perf-space-5403ca46-a079-11ef-bb1e-02420a0a0007/static#blue/...

Restoring prior application state: STARTED
Application static#blue was successfully changed to Stack cflinuxfs4
```
```
cf curl "/v3/apps?names=static%23blue"
{"pagination":{"total_results":1,"total_pages":1,"first":
{"href":"https://api.sys.tas.z3c9041a1.shepherd.lease/v3/apps?names=static%23blue\u0026page=1\u0026per_page=50"}
,"last":{"href":"https://api.sys.tas.z3c9041a1.shepherd.lease/v3/apps?names=static%23blue\u0026page=1\u0026per_page=50"},"next":null,"previous":null},"resources":[{"guid":"903ee4b0-138d-48d7-9a17-081272812342","created_at":"2024-11-12T16:42:30Z","updated_at":"2024-11-12T16:54:20Z","name":"static#blue","state":"STARTED","lifecycle":{"type":"buildpack","data":{"buildpacks":["staticfile_buildpack"],"stack":"cflinuxfs3"}},"relationships":{"space":{"data":{"guid":"5403ca41-a079-11ef-.....
 ```
 
Looked at the rest of the CF client in stack auditor and can find no other need for escaping. All other query params are either integers through pages or guids.