### PR TITLE
Deprecate io/ioutil

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -243,7 +242,7 @@ func GetOrgAndSpace() (string, string, error) {
 	if cfHome == "" {
 		cfHome = os.Getenv("HOME")
 	}
-	bytes, err := ioutil.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
+	bytes, err := os.ReadFile(filepath.Join(cfHome, ".cf", "config.json"))
 	if err != nil {
 		return "", "", err
 	}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -2,7 +2,7 @@ package mocks
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -117,7 +117,7 @@ func FileToString(fileName string) ([]string, error) {
 		return nil, err
 	}
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,8 +15,8 @@ func (c Command) Run(bin, dir string, quiet bool, args ...string) error {
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = dir
 	if quiet {
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
 	} else {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -31,8 +30,8 @@ func (c Command) RunWithOutput(bin, dir string, quiet bool, args ...string) (str
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = dir
 	if quiet {
-		cmd.Stdout = io.MultiWriter(ioutil.Discard, logs)
-		cmd.Stderr = io.MultiWriter(ioutil.Discard, logs)
+		cmd.Stdout = io.MultiWriter(io.Discard, logs)
+		cmd.Stderr = io.MultiWriter(io.Discard, logs)
 	} else {
 		cmd.Stdout = io.MultiWriter(os.Stdout, logs)
 		cmd.Stderr = io.MultiWriter(os.Stderr, logs)


### PR DESCRIPTION
Starting go 1.16 "io/ioutil" is deprecated